### PR TITLE
fix: properly order text elements & return array of links | /workflows/cd

### DIFF
--- a/polywrap.deploy.yaml
+++ b/polywrap.deploy.yaml
@@ -12,7 +12,7 @@ jobs:
         package: http
         uri: $$ipfs_deploy
         config:
-          postUrl: https://wraps.wrapscan.io/r/polywrap/web-scraper@1.0.1
+          postUrl: https://wraps.wrapscan.io/r/polywrap/web-scraper@1.0.2
           headers:
             - name: Authorization
               value: $POLYWRAP_WRAPSCAN_AUTH_HEADER_PROD

--- a/polywrap.graphql
+++ b/polywrap.graphql
@@ -2,5 +2,5 @@
 
 type Module {
   get_text(url: String!): String!
-  get_links(url: String!): String!
+  get_links(url: String!): [String!]!
 }

--- a/src/__tests__/e2e/integration.spec.ts
+++ b/src/__tests__/e2e/integration.spec.ts
@@ -17,33 +17,45 @@ describe("WebScraper", () => {
     });
     expect(result.ok).toBeTruthy();
     if (!result.ok) return;
-    expect(result.value).toContain(`/
-#page-top
-/
-/cloud-scraper
-/pricing
-#section3
-/documentation
-/tutorials
-/how-to-videos
-/test-sites
-https://forum.webscraper.io/
-https://chrome.google.com/webstore/detail/web-scraper/jnhgnonknehpejjnehehllkliplmbmhn?hl=en
-https://cloud.webscraper.io/
-/test-sites/e-commerce/allinone
-/test-sites/e-commerce/allinone/phones
-/test-sites/e-commerce/allinone/computers`
-    );
+    expect(result.value).toEqual(expect.arrayContaining([
+      "/",
+      "#page-top",
+      "/",
+      "/cloud-scraper",
+      "/pricing",
+      "#section3",
+      "/documentation",
+      "/tutorials",
+      "/how-to-videos",
+      "/test-sites",
+      "https://forum.webscraper.io/",
+      "https://chrome.google.com/webstore/detail/web-scraper/jnhgnonknehpejjnehehllkliplmbmhn?hl=en",
+      "https://cloud.webscraper.io/",
+      "/test-sites/e-commerce/allinone",
+      "/test-sites/e-commerce/allinone/phones",
+      "/test-sites/e-commerce/allinone/computers",
+    ]));
   });
 
   it("get_text", async () => {
     const result = await webScraper.get_text({
-      url: "\nhttps://webscraper.io/test-sites/e-commerce/allinone\n"
+      url: "https://webscraper.io/test-sites/e-commerce/allinone"
     });
     expect(result.ok).toBeTruthy();
     if (!result.ok) return;
     expect(result.value).toContain(
       `Web Scraper\nCloud Scraper\n`
+    );
+  });
+
+  it("get_text 2", async () => {
+    const result = await webScraper.get_text({
+      url: "https://silennaihin.com/random/plain.html"
+    });
+    expect(result.ok).toBeTruthy();
+    if (!result.ok) return;
+    expect(result.value).toContain(
+      `This is a Heading\nThis is a paragraph.`
     );
   });
 });


### PR DESCRIPTION
* `get_text` was not order elements properly.
* `get_links` should return an array of links